### PR TITLE
Fix: Remove navbar from cache.

### DIFF
--- a/src/AnnetKatan/Views/Shared/_Layout.cshtml
+++ b/src/AnnetKatan/Views/Shared/_Layout.cshtml
@@ -22,9 +22,7 @@
 <body>
 
   <div class="container">
-
-    <cache expires-after="@TimeSpan.FromDays(1)">
-
+  
       <div class="header">
         <div class="masthead clearfix">
           <div class="masthead-brand">
@@ -41,8 +39,6 @@
           </ul>
         </div>
       </div>
-
-    </cache>
 
     <div class="jumbotron">
       @RenderBody()


### PR DESCRIPTION
Remove navbar from cache, because it causes an issue with active menu
item.